### PR TITLE
Recruitment rolls a chance per enemy

### DIFF
--- a/Assets/Scripts/CombatController.cs
+++ b/Assets/Scripts/CombatController.cs
@@ -566,8 +566,11 @@ public class CombatController : MonoBehaviour
 
         Debug.Log("Victory");
 
-        int recruitmentChance = UnityEngine.Random.Range(0, PartyController.partyMembers.Select((PartyController.PartyMember? member) => member.HasValue).ToArray().Length);
-        if (recruitmentChance == 0 || formation.monsters[0].combatantName.Equals("Wolf"))
+        HashSet<int> recruitmentChance = new HashSet<int>();
+        while (recruitmentChance.Count < formation.monsters.Count())
+            recruitmentChance.Add(UnityEngine.Random.Range(0, PartyController.partyMembers.Select((PartyController.PartyMember? member) => member.HasValue).ToArray().Length));
+
+        if (recruitmentChance.Contains(0) || formation.monsters[0].combatantName.Equals("Wolf"))
         {
             //Begin recruitment
             yield return recruitmentController.PitchRecruitment(formation);


### PR DESCRIPTION
Now a recruitment chance will roll per enemy in a formation rather once per formation. This should give higher odds for recruiting a creature after big fights while not effecting odds on solo fights.