### PR TITLE
Fixed bug preventing equipment from being reset

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -857,13 +857,19 @@ MonoBehaviour:
     partyMemberBaseStats: {fileID: 11400000, guid: 998b75cfe3f38644e843342591665e9c, type: 2}
     currentHP: 0
     currentSP: 0
-  protagonistEquipmentNonstatic:
+  initialEquipment:
     weapon: {fileID: 11400000, guid: a849ab1efa5ed3243bc0df49e80d4442, type: 2}
     defense: {fileID: 11400000, guid: 6beae0ee0e91374459d337379f5b80a8, type: 2}
     trinkets:
     - {fileID: 0}
     - {fileID: 0}
   partyMonsters: []
+  protagonistEquipmentNonstatic:
+    weapon: {fileID: 11400000, guid: a849ab1efa5ed3243bc0df49e80d4442, type: 2}
+    defense: {fileID: 11400000, guid: 6beae0ee0e91374459d337379f5b80a8, type: 2}
+    trinkets:
+    - {fileID: 0}
+    - {fileID: 0}
 --- !u!4 &1796975613
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Systems/PartyController.cs
+++ b/Assets/Scripts/Systems/PartyController.cs
@@ -15,7 +15,7 @@ public class PartyController : MonoBehaviour
     }
 
     [Serializable]
-    public struct ProtagonistEquipment
+    public class ProtagonistEquipment
     {
         public EquipmentScriptableObject weapon;
         public EquipmentScriptableObject defense;
@@ -25,8 +25,9 @@ public class PartyController : MonoBehaviour
     public static PartyMember?[] partyMembers = new PartyMember?[4];
     public static ProtagonistEquipment protagonistEquipment;
     public PartyMember protagonist;
-    public ProtagonistEquipment protagonistEquipmentNonstatic;
+    [SerializeField] private ProtagonistEquipment initialEquipment;
     public PartyMember[] partyMonsters;
+    [SerializeField] private ProtagonistEquipment protagonistEquipmentNonstatic;
 
     private void OnEnable()
     {
@@ -67,7 +68,6 @@ public class PartyController : MonoBehaviour
         tempProtag.currentHP = tempProtag.partyMemberBaseStats.combatantMaxHealth;
         tempProtag.currentSP = tempProtag.partyMemberBaseStats.combatantMaxStamina;
         partyMembers[0] = tempProtag;
-        protagonistEquipmentNonstatic = protagonistEquipment;
 
         for (int i = 0; i < 3; i++)
         {
@@ -148,7 +148,25 @@ public class PartyController : MonoBehaviour
     {
         Array.Clear(partyMembers, 0, partyMembers.Length);
         Array.Clear(partyMonsters, 0, partyMonsters.Length);
-        protagonistEquipment = protagonistEquipmentNonstatic;
+        ResetProtagonistEquipment();
         SetPartyValues();
+    }
+
+    private void ResetProtagonistEquipment()
+    {
+        if (protagonistEquipment == null)
+        {
+            protagonistEquipment = new ProtagonistEquipment();
+            protagonistEquipment.trinkets = new EquipmentScriptableObject[initialEquipment.trinkets.Length];
+        }
+
+        protagonistEquipment.weapon = initialEquipment.weapon;
+        protagonistEquipment.defense = initialEquipment.defense;
+        protagonistEquipment.trinkets[0] = initialEquipment.trinkets[0];
+        protagonistEquipment.trinkets[1] = initialEquipment.trinkets[1];
+
+        // Assigns protagonistEquipment memory address to protagonistEquipmentNonstatic
+        // Therefore, we don't need to update it when ever protagonistEquipment is updated
+        protagonistEquipmentNonstatic = protagonistEquipment;
     }
 }


### PR DESCRIPTION
All the protagonist equipment variables shared the same memory address, so the initial equipment was updated along with the main static value.

I've made the static value allocate to a new memory address.