### PR TITLE
Fixed second target duo bug

### DIFF
--- a/Assets/Scripts/Combat/UI/BattleUIController.cs
+++ b/Assets/Scripts/Combat/UI/BattleUIController.cs
@@ -179,7 +179,7 @@ public class BattleUIController : MonoBehaviour
             case 3:
                 for (int i = 0; i < 3; i++)
                 {
-                    monsterTargetButtons[i].transform.gameObject.SetActive(aliveTargets[i]);
+                    monsterTargetButtons[i].gameObject.SetActive(aliveTargets[i]);
 
                     customNav = monsterTargetButtons[i].navigation;
                     customNav.mode = Navigation.Mode.Explicit;
@@ -197,7 +197,7 @@ public class BattleUIController : MonoBehaviour
                 monsterTargetButtons[currentSelected].Select();
                 break;
             case 2:
-                monsterTargetButtons[1].enabled = false;
+                monsterTargetButtons[1].gameObject.SetActive(false);
                 for (int i = 0; i < 2; i++)
                 {
                     monsterTargetButtons[i * 2].transform.gameObject.SetActive(aliveTargets[i * 2]);
@@ -211,7 +211,7 @@ public class BattleUIController : MonoBehaviour
                 monsterTargetButtons[currentSelected].Select();
                 break;
             case 1:
-                monsterTargetButtons[1].transform.gameObject.SetActive(true);
+                monsterTargetButtons[1].gameObject.SetActive(true);
                 customNav = monsterTargetButtons[1].navigation;
                 customNav.mode = Navigation.Mode.None;
                 monsterTargetButtons[1].navigation = customNav;


### PR DESCRIPTION
The second target in a duo battle couldn't be selected. This was caused by the middle combatant (who is not present for this fight) being selected with no possible way to navigate to the second target. The middle combatant's target game object is disabled in duo fights.