### PR TITLE
Fixed minimap player desync bug

### DIFF
--- a/Assets/Scripts/Field/FieldMovementController.cs
+++ b/Assets/Scripts/Field/FieldMovementController.cs
@@ -6,6 +6,7 @@ public class FieldMovementController : MonoBehaviour
 {
     public static event Action<Vector3> PlayerPositionChanged;
     public static event Action<Vector3> PlayerRotationChanged;
+    public static event Action<Vector3> SetPlayerRotation;
     public static event Action TreasureFound;
     public static event Action<Animator> TreasureFoundAnimator;
 
@@ -54,6 +55,9 @@ public class FieldMovementController : MonoBehaviour
     {
         onTitle = false;
         lockedInPlace = false;
+
+        if (SetPlayerRotation != null)
+            SetPlayerRotation.Invoke(-transform.rotation.eulerAngles);
     }
 
     private void ResetPlayerPosition()

--- a/Assets/Scripts/Systems/MinimapController.cs
+++ b/Assets/Scripts/Systems/MinimapController.cs
@@ -25,6 +25,7 @@ public class MinimapController : MonoBehaviour
         MazeGenerator.MazeTextureGenerated += DrawNewMinimap;
         FieldMovementController.PlayerPositionChanged += UpdatePlayerPosition;
         FieldMovementController.PlayerRotationChanged += UpdatePlayerRotation;
+        FieldMovementController.SetPlayerRotation += SetPlayerRotation;
     }
 
     private void OnDisable()
@@ -32,6 +33,7 @@ public class MinimapController : MonoBehaviour
         MazeGenerator.MazeTextureGenerated -= DrawNewMinimap;
         FieldMovementController.PlayerPositionChanged -= UpdatePlayerPosition;
         FieldMovementController.PlayerRotationChanged -= UpdatePlayerRotation;
+        FieldMovementController.SetPlayerRotation -= SetPlayerRotation;
     }
 
     private void DrawNewMinimap(Texture2D mazeTexture)
@@ -130,6 +132,11 @@ public class MinimapController : MonoBehaviour
     private void UpdatePlayerRotation(Vector3 newRotation)
     {
         playerEntity.Rotate(newRotation);
+    }
+
+    private void SetPlayerRotation(Vector3 playerRotation)
+    {
+        playerEntity.rotation = Quaternion.Euler(new Vector3(0, 0, playerRotation.y));
     }
 
     private void SetPortalPosition(Vector2 portalPosition)


### PR DESCRIPTION
The bug was caused by the player controller rotating to the correct location before the combat scene was loaded. The minimap controller which handles the rotation of the minimap player icon is held within the combat controller scene. Since the player invokes the player rotation changed event when the listener isn't active, it doesn't update the minimap player icon.

I've added another event that will set the minimap player icon once the combat scene has loaded proper, eliminating this issue.