### PR TITLE
Can no longer walk after closing manual in combat

### DIFF
--- a/Assets/Scripts/Field/FieldMovementController.cs
+++ b/Assets/Scripts/Field/FieldMovementController.cs
@@ -52,13 +52,11 @@ public class FieldMovementController : MonoBehaviour
     private void OnTitle()
     {
         onTitle = true;
-        lockedInPlace = false;
     }
 
     private void OnCombat()
     {
         onTitle = false;
-        lockedInPlace = false;
 
         if (SetPlayerRotation != null)
             SetPlayerRotation.Invoke(-transform.rotation.eulerAngles);
@@ -66,6 +64,7 @@ public class FieldMovementController : MonoBehaviour
 
     private void ResetPlayerPosition()
     {
+        lockedInPlace = false;
         StartCoroutine(WaitForAnimationToStop());
     }
 


### PR DESCRIPTION
Fixed a bug where closing the manual would disabled their lockedInPlace boolean allowing them to walk, interact with rifts, and get into more combat while they are already in combat. This bug occurred due to a bandaid fix applied earlier where the player couldn't move upon resetting from a game over.